### PR TITLE
Integration - caching the model and fixing a multiprocessing bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 data
+.zed

--- a/common/common.py
+++ b/common/common.py
@@ -72,6 +72,10 @@ def mask_to_polygons(mask, dataset_reader):
                                            mode=cv2.RETR_CCOMP,
                                            method=cv2.CHAIN_APPROX_SIMPLE)
 
+    # if no contours are found, return empty list
+    if hierarchy is None or len(hierarchy) == 0:
+        return []
+
     hierarchy = hierarchy[0]
 
     poly = merge_polygons(contours, hierarchy)

--- a/common/common.py
+++ b/common/common.py
@@ -11,155 +11,152 @@ import rasterio.warp
 import rasterio.enums
 from rasterio.vrt import WarpedVRT
 
-def get_utm_string_from_latlon(lat, lon):
-    zone = utm.from_latlon(lat, lon)
-    utm_code = 32600 + zone[2]
-    if lat < 0:
-        utm_code -= 100
 
-    return f"EPSG:{utm_code}"
+def get_utm_string_from_latlon(lat, lon):
+	zone = utm.from_latlon(lat, lon)
+	utm_code = 32600 + zone[2]
+	if lat < 0:
+		utm_code -= 100
+
+	return f'EPSG:{utm_code}'
 
 
 def merge_polygons(contours, hierarchy) -> MultiPolygon:
-    # https://docs.opencv.org/4.x/d9/d8b/tutorial_py_contours_hierarchy.html
-    # hierarchy structure: [next, prev, first_child, parent]
+	# https://docs.opencv.org/4.x/d9/d8b/tutorial_py_contours_hierarchy.html
+	# hierarchy structure: [next, prev, first_child, parent]
 
-    def make_valid(polygon):
-        if not polygon.is_valid:
-            polygon = polygon.buffer(0)
-        return polygon
+	def make_valid(polygon):
+		if not polygon.is_valid:
+			polygon = polygon.buffer(0)
+		return polygon
 
-    polygons = []
+	polygons = []
 
-    idx = 0
-    while idx != -1:
-        # Get contour from global list of contours
-        contour = np.squeeze(contours[idx])
+	idx = 0
+	while idx != -1:
+		# Get contour from global list of contours
+		contour = np.squeeze(contours[idx])
 
-        # cv2.findContours() sometimes returns a single point -> skip this case
-        if len(contour) > 2:
-            # Convert contour to shapely polygon
-            holes = []
+		# cv2.findContours() sometimes returns a single point -> skip this case
+		if len(contour) > 2:
+			# Convert contour to shapely polygon
+			holes = []
 
-            # check if there is a child
-            child_idx = hierarchy[idx][2]
-            if child_idx != -1:
-                # iterate over all children and add them as holes
-                while child_idx != -1:
-                    child = np.squeeze(contours[child_idx])
-                    if len(child) > 2:
-                        holes.append(child)
-                    child_idx = hierarchy[child_idx][0]
+			# check if there is a child
+			child_idx = hierarchy[idx][2]
+			if child_idx != -1:
+				# iterate over all children and add them as holes
+				while child_idx != -1:
+					child = np.squeeze(contours[child_idx])
+					if len(child) > 2:
+						holes.append(child)
+					child_idx = hierarchy[child_idx][0]
 
-            new_poly = Polygon(shell=contour, holes=holes)
+			new_poly = Polygon(shell=contour, holes=holes)
 
-            # save poly
-            polygons.append(new_poly)
+			# save poly
+			polygons.append(new_poly)
 
-        # Check if there is some next polygon at the same hierarchy level
-        idx = hierarchy[idx][0]
+		# Check if there is some next polygon at the same hierarchy level
+		idx = hierarchy[idx][0]
 
-    return polygons
+	return polygons
 
 
 def mask_to_polygons(mask, dataset_reader):
-    """
-    this function takes a numpy mask as input and returns a list of polygons
-    that are in the crs of the passed dataset reader
-    """
+	"""
+	this function takes a numpy mask as input and returns a list of polygons
+	that are in the crs of the passed dataset reader
+	"""
 
-    contours, hierarchy = cv2.findContours(mask.astype(np.uint8).copy(),
-                                           mode=cv2.RETR_CCOMP,
-                                           method=cv2.CHAIN_APPROX_SIMPLE)
+	contours, hierarchy = cv2.findContours(
+		mask.astype(np.uint8).copy(), mode=cv2.RETR_CCOMP, method=cv2.CHAIN_APPROX_SIMPLE
+	)
 
-    # if no contours are found, return empty list
-    if hierarchy is None or len(hierarchy) == 0:
-        return []
+	# if no contours are found, return empty list
+	if hierarchy is None or len(hierarchy) == 0:
+		return []
 
-    hierarchy = hierarchy[0]
+	hierarchy = hierarchy[0]
 
-    poly = merge_polygons(contours, hierarchy)
+	poly = merge_polygons(contours, hierarchy)
 
-    # affine transform from pixel to world coordinates
-    transform = dataset_reader.transform
-    transform_matrix = (transform.a, transform.b, transform.d, transform.e,
-                        transform.c, transform.f)
-    poly = [affine_transform(p, transform_matrix) for p in poly]
+	# affine transform from pixel to world coordinates
+	transform = dataset_reader.transform
+	transform_matrix = (transform.a, transform.b, transform.d, transform.e, transform.c, transform.f)
+	poly = [affine_transform(p, transform_matrix) for p in poly]
 
-    return poly
+	return poly
 
 
 def save_poly(filename, poly, crs):
-    """saves the polygons to a file in the given crs"""
-    gpd.GeoDataFrame(geometry=poly, crs=crs).to_file(filename)
+	"""saves the polygons to a file in the given crs"""
+	gpd.GeoDataFrame(geometry=poly, crs=crs).to_file(filename)
 
 
 def image_reprojector(input_tif, min_res=0, max_res=1e9):
-    dataset = rasterio.open(input_tif)
-    centroid = dataset.lnglat()
-    utm_crs = get_utm_string_from_latlon(centroid[1], centroid[0])
+	dataset = rasterio.open(input_tif)
+	centroid = dataset.lnglat()
+	utm_crs = get_utm_string_from_latlon(centroid[1], centroid[0])
 
-    default_transform, width, height = rasterio.warp.calculate_default_transform(
-        dataset.crs, utm_crs, dataset.width, dataset.height, *dataset.bounds)
+	default_transform, width, height = rasterio.warp.calculate_default_transform(
+		dataset.crs, utm_crs, dataset.width, dataset.height, *dataset.bounds
+	)
 
-    # get original resolution
-    orig_res = default_transform.a
+	# get original resolution
+	orig_res = default_transform.a
 
-    target_res = None
-    if orig_res < min_res:
-        target_res = min_res
-        print(
-            f"Original resolution ({orig_res}) is smaller than minimum resolution ({min_res}). Reprojecting to minimum resolution."
-        )
-    if orig_res > max_res:
-        target_res = max_res
-        print(
-            f"Original resolution ({orig_res}) is larger than maximum resolution ({max_res}). Reprojecting to maximum resolution."
-        )
+	target_res = None
+	if orig_res < min_res:
+		target_res = min_res
+		print(
+			f'Original resolution ({orig_res}) is smaller than minimum resolution ({min_res}). Reprojecting to minimum resolution.'
+		)
+	if orig_res > max_res:
+		target_res = max_res
+		print(
+			f'Original resolution ({orig_res}) is larger than maximum resolution ({max_res}). Reprojecting to maximum resolution.'
+		)
 
-    if target_res is not None:
-        default_transform, width, height = rasterio.warp.calculate_default_transform(
-            dataset.crs,
-            utm_crs,
-            dataset.width,
-            dataset.height,
-            *dataset.bounds,
-            resolution=target_res)
-        
-    vrt = WarpedVRT(dataset, crs=utm_crs, transform=default_transform, width=width, height=height, dtype="uint8", nodata=0)
+	if target_res is not None:
+		default_transform, width, height = rasterio.warp.calculate_default_transform(
+			dataset.crs, utm_crs, dataset.width, dataset.height, *dataset.bounds, resolution=target_res
+		)
 
-    return vrt
+	vrt = WarpedVRT(
+		dataset, crs=utm_crs, transform=default_transform, width=width, height=height, dtype='uint8', nodata=0
+	)
+
+	return vrt
 
 
 def reproject_polygons(polygons, src_crs, dst_src):
-    """
-    reprojects the polygons from the src_crs to the dst_crs
-    """
-    rep = rasterio.warp.transform_geom(src_crs, dst_src, polygons)
-    if isinstance(rep, list):
-        return shapely.from_geojson([json.dumps(x) for x in rep])
-    else:
-        return shapely.from_geojson(json.dumps(rep))
+	"""
+	reprojects the polygons from the src_crs to the dst_crs
+	"""
+	rep = rasterio.warp.transform_geom(src_crs, dst_src, polygons)
+	if isinstance(rep, list):
+		return shapely.from_geojson([json.dumps(x) for x in rep])
+	else:
+		return shapely.from_geojson(json.dumps(rep))
 
 
 def filter_polygons_by_area(polygons, min_area):
-    """
-    filters the polygons by the minimum area
-    """
-    filtered = []
-    for p in polygons:
+	"""
+	filters the polygons by the minimum area
+	"""
+	filtered = []
+	for p in polygons:
+		exterior = p.exterior
 
-        exterior = p.exterior
+		# Filter holes (interior rings) by area
+		filtered_holes = [hole for hole in p.interiors if Polygon(hole).area >= min_area]
 
-        # Filter holes (interior rings) by area
-        filtered_holes = [hole for hole in p.interiors
-                         if Polygon(hole).area >= min_area]
+		# Create new polygon with filtered holes
+		filtered_p = Polygon(exterior, filtered_holes)
 
-        # Create new polygon with filtered holes
-        filtered_p = Polygon(exterior, filtered_holes)
+		if filtered_p.area >= min_area:
+			filtered.append(p)
 
-        if filtered_p.area >= min_area:
-            filtered.append(p)
-
-    print(f"Filtered {len(polygons) - len(filtered)} polygons by minimum area of {min_area}m2.")
-    return filtered
+	print(f'Filtered {len(polygons) - len(filtered)} polygons by minimum area of {min_area}m2.')
+	return filtered

--- a/deadwood/InferenceDataset.py
+++ b/deadwood/InferenceDataset.py
@@ -6,12 +6,11 @@ import numpy as np
 
 
 class InferenceDataset(Dataset):
-    def __init__(self, image_path, tile_size=512, padding=56):
+    def __init__(self, image_src, tile_size=512, padding=56):
         super(InferenceDataset, self).__init__()
         self.tile_size = tile_size
         self.padding = padding
-        self.image_path = image_path
-        self.image_src = rasterio.open(self.image_path)
+        self.image_src = image_src
         self.width = self.image_src.width
         self.height = self.image_src.height
 

--- a/deadwood/InferenceDataset.py
+++ b/deadwood/InferenceDataset.py
@@ -2,73 +2,76 @@ import rasterio
 from rasterio import windows
 from torch.utils.data import Dataset
 from torchvision.transforms import transforms
+import torch
 
 
 class InferenceDataset(Dataset):
+	def __init__(self, image_path, tile_size=512, padding=56):
+		super(InferenceDataset, self).__init__()
+		self.image_path = image_path
+		self.tile_size = tile_size
+		self.padding = padding
+		self.image_src = rasterio.open(self.image_path)
+		self.width = self.image_src.width
+		self.height = self.image_src.height
 
-    def __init__(self, image_path, tile_size=512, padding=56):
-        super(InferenceDataset, self).__init__()
-        self.image_path = image_path
-        self.tile_size = tile_size
-        self.padding = padding
-        self.image_src = rasterio.open(self.image_path)
-        self.width = self.image_src.width
-        self.height = self.image_src.height
+		self.cropped_windows = [
+			window
+			for window in get_windows(
+				xmin=self.padding,
+				ymin=self.padding,
+				xmax=self.width - self.padding,
+				ymax=self.height - self.padding,
+				tile_width=self.tile_size - (padding * 2),
+				tile_height=self.tile_size - (padding * 2),
+				overlap=0,
+			)
+		]
 
-        self.cropped_windows = [
-            window for window in get_windows(
-                xmin=self.padding,
-                ymin=self.padding,
-                xmax=self.width - self.padding,
-                ymax=self.height - self.padding,
-                tile_width=self.tile_size - (padding * 2),
-                tile_height=self.tile_size - (padding * 2),
-                overlap=0,
-            )
-        ]
+	def __len__(self):
+		return len(self.cropped_windows)
 
-    def __len__(self):
-        return len(self.cropped_windows)
+	def __getitem__(self, idx):
+		image_src = rasterio.open(self.image_path)
+		cropped_window = self.cropped_windows[idx]
+		cropped_window_dict = {
+			'col_off': cropped_window.col_off,
+			'row_off': cropped_window.row_off,
+			'width': cropped_window.width,
+			'height': cropped_window.height,
+		}
+		inference_window = windows.Window(
+			cropped_window.col_off - self.padding,
+			cropped_window.row_off - self.padding,
+			cropped_window.width + (2 * self.padding),
+			cropped_window.height + (2 * self.padding),
+		)
+		image = image_src.read((1, 2, 3), window=inference_window)
 
-    def __getitem__(self, idx):
-        image_src = rasterio.open(self.image_path)
-        cropped_window = self.cropped_windows[idx]
-        cropped_window_dict = {
-            "col_off": cropped_window.col_off,
-            "row_off": cropped_window.row_off,
-            "width": cropped_window.width,
-            "height": cropped_window.height,
-        }
-        inference_window = windows.Window(
-            cropped_window.col_off - self.padding,
-            cropped_window.row_off - self.padding,
-            cropped_window.width + (2 * self.padding),
-            cropped_window.height + (2 * self.padding),
-        )
-        image = image_src.read((1, 2, 3), window=inference_window)
+		# Reshape the image tensor to have 3 channels
+		image = image.transpose(1, 2, 0)
 
-        # Reshape the image tensor to have 3 channels
-        image = image.transpose(1, 2, 0)
-
-        image_transforms = transforms.Compose([
-            transforms.ToTensor(),
-            transforms.Normalize(
-                mean=[0.485, 0.456, 0.406],
-                std=[0.229, 0.224, 0.225],
-            ),
-        ])
-        image_tensor = image_transforms(image).float().contiguous()
-        return image_tensor, cropped_window_dict
+		image_transforms = transforms.Compose(
+			[
+				transforms.ToTensor(),
+				transforms.Normalize(
+					mean=[0.485, 0.456, 0.406],
+					std=[0.229, 0.224, 0.225],
+				),
+			]
+		)
+		image_tensor = image_transforms(image).float().contiguous()
+		return image_tensor, cropped_window_dict
 
 
 def get_windows(xmin, ymin, xmax, ymax, tile_width, tile_height, overlap):
-    xstep = tile_width - overlap
-    ystep = tile_height - overlap
-    for x in range(xmin, xmax, xstep):
-        if x + tile_width > xmax:
-            x = xmax - tile_width
-        for y in range(ymin, ymax, ystep):
-            if y + tile_height > ymax:
-                y = ymax - tile_height
-            window = windows.Window(x, y, tile_width, tile_height)
-            yield window
+	xstep = tile_width - overlap
+	ystep = tile_height - overlap
+	for x in range(xmin, xmax, xstep):
+		if x + tile_width > xmax:
+			x = xmax - tile_width
+		for y in range(ymin, ymax, ystep):
+			if y + tile_height > ymax:
+				y = ymax - tile_height
+			window = windows.Window(x, y, tile_width, tile_height)
+			yield window

--- a/deadwood/InferenceDataset.py
+++ b/deadwood/InferenceDataset.py
@@ -6,89 +6,89 @@ import numpy as np
 
 
 class InferenceDataset(Dataset):
-    def __init__(self, image_src, tile_size=512, padding=56):
-        super(InferenceDataset, self).__init__()
-        self.tile_size = tile_size
-        self.padding = padding
-        self.image_src = image_src
-        self.width = self.image_src.width
-        self.height = self.image_src.height
+	def __init__(self, image_src, tile_size=512, padding=56):
+		super(InferenceDataset, self).__init__()
+		self.tile_size = tile_size
+		self.padding = padding
+		self.image_src = image_src
+		self.width = self.image_src.width
+		self.height = self.image_src.height
 
-        self.cropped_windows = [
-            window for window in get_windows(
-                xmin=-self.padding,
-                ymin=-self.padding,
-                xmax=self.width + self.padding,
-                ymax=self.height + self.padding,
-                tile_width=self.tile_size - (padding * 2),
-                tile_height=self.tile_size - (padding * 2),
-                overlap=0,
-            )
-        ]
+		self.cropped_windows = [
+			window
+			for window in get_windows(
+				xmin=-self.padding,
+				ymin=-self.padding,
+				xmax=self.width + self.padding,
+				ymax=self.height + self.padding,
+				tile_width=self.tile_size - (padding * 2),
+				tile_height=self.tile_size - (padding * 2),
+				overlap=0,
+			)
+		]
 
-    def __len__(self):
-        return len(self.cropped_windows)
+	def __len__(self):
+		return len(self.cropped_windows)
 
-    def __getitem__(self, idx):
-        cropped_window = self.cropped_windows[idx]
-        cropped_window_dict = {
-            "col_off": cropped_window.col_off,
-            "row_off": cropped_window.row_off,
-            "width": cropped_window.width,
-            "height": cropped_window.height,
-        }
-        inference_window = windows.Window(
-            cropped_window.col_off - self.padding,
-            cropped_window.row_off - self.padding,
-            cropped_window.width + (2 * self.padding),
-            cropped_window.height + (2 * self.padding),
-        )
-        image = self.image_src.read((1, 2, 3), window=inference_window)
+	def __getitem__(self, idx):
+		cropped_window = self.cropped_windows[idx]
+		cropped_window_dict = {
+			'col_off': cropped_window.col_off,
+			'row_off': cropped_window.row_off,
+			'width': cropped_window.width,
+			'height': cropped_window.height,
+		}
+		inference_window = windows.Window(
+			cropped_window.col_off - self.padding,
+			cropped_window.row_off - self.padding,
+			cropped_window.width + (2 * self.padding),
+			cropped_window.height + (2 * self.padding),
+		)
+		image = self.image_src.read((1, 2, 3), window=inference_window)
 
-        # enable boundless reads also for VRTs by adding padding of zeros if necessary
-        if image.shape[1] < self.tile_size or image.shape[2] < self.tile_size:
+		# enable boundless reads also for VRTs by adding padding of zeros if necessary
+		if image.shape[1] < self.tile_size or image.shape[2] < self.tile_size:
+			pad_left = 0 if inference_window.col_off >= 0 else abs(inference_window.col_off)
+			pad_right = self.tile_size - (pad_left + image.shape[2])
 
-            pad_left = 0 if inference_window.col_off >= 0 else abs(
-                inference_window.col_off)
-            pad_right = self.tile_size - (pad_left + image.shape[2])
+			pad_top = 0 if inference_window.row_off >= 0 else abs(inference_window.row_off)
+			pad_bottom = self.tile_size - (pad_top + image.shape[1])
 
-            pad_top = 0 if inference_window.row_off >= 0 else abs(
-                inference_window.row_off)
-            pad_bottom = self.tile_size - (pad_top + image.shape[1])
+			image = np.pad(
+				image,
+				(
+					(0, 0),
+					(pad_top, pad_bottom),
+					(pad_left, pad_right),
+				),
+				mode='constant',
+				constant_values=0,
+			)
 
-            image = np.pad(
-                image,
-                (
-                    (0, 0),
-                    (pad_top, pad_bottom),
-                    (pad_left, pad_right),
-                ),
-                mode="constant",
-                constant_values=0,
-            )
+		# Reshape the image tensor to have 3 channels
+		image = image.transpose(1, 2, 0)
 
-        # Reshape the image tensor to have 3 channels
-        image = image.transpose(1, 2, 0)
-
-        image_transforms = transforms.Compose([
-            transforms.ToTensor(),
-            transforms.Normalize(
-                mean=[0.485, 0.456, 0.406],
-                std=[0.229, 0.224, 0.225],
-            ),
-        ])
-        image_tensor = image_transforms(image).float().contiguous()
-        return image_tensor, cropped_window_dict
+		image_transforms = transforms.Compose(
+			[
+				transforms.ToTensor(),
+				transforms.Normalize(
+					mean=[0.485, 0.456, 0.406],
+					std=[0.229, 0.224, 0.225],
+				),
+			]
+		)
+		image_tensor = image_transforms(image).float().contiguous()
+		return image_tensor, cropped_window_dict
 
 
 def get_windows(xmin, ymin, xmax, ymax, tile_width, tile_height, overlap):
-    xstep = tile_width - overlap
-    ystep = tile_height - overlap
-    for x in range(xmin, xmax, xstep):
-        if x + tile_width > xmax:
-            x = xmax - tile_width
-        for y in range(ymin, ymax, ystep):
-            if y + tile_height > ymax:
-                y = ymax - tile_height
-            window = windows.Window(x, y, tile_width, tile_height)
-            yield window
+	xstep = tile_width - overlap
+	ystep = tile_height - overlap
+	for x in range(xmin, xmax, xstep):
+		if x + tile_width > xmax:
+			x = xmax - tile_width
+		for y in range(ymin, ymax, ystep):
+			if y + tile_height > ymax:
+				y = ymax - tile_height
+			window = windows.Window(x, y, tile_width, tile_height)
+			yield window

--- a/deadwood/InferenceDataset.py
+++ b/deadwood/InferenceDataset.py
@@ -2,95 +2,94 @@ import rasterio
 from rasterio import windows
 from torch.utils.data import Dataset
 from torchvision.transforms import transforms
-import torch
 import numpy as np
 
 
 class InferenceDataset(Dataset):
-	def __init__(self, image_path, tile_size=512, padding=56):
-		super(InferenceDataset, self).__init__()
-		self.image_path = image_path
-		self.tile_size = tile_size
-		self.padding = padding
-		self.image_src = rasterio.open(self.image_path)
-		self.width = self.image_src.width
-		self.height = self.image_src.height
+    def __init__(self, image_path, tile_size=512, padding=56):
+        super(InferenceDataset, self).__init__()
+        self.tile_size = tile_size
+        self.padding = padding
+        self.image_path = image_path
+        self.image_src = rasterio.open(self.image_path)
+        self.width = self.image_src.width
+        self.height = self.image_src.height
 
-		self.cropped_windows = [
-			window
-			for window in get_windows(
-				xmin=-self.padding,
-				ymin=-self.padding,
-				xmax=self.width + self.padding,
-				ymax=self.height + self.padding,
-				tile_width=self.tile_size - (padding * 2),
-				tile_height=self.tile_size - (padding * 2),
-				overlap=0,
-			)
-		]
+        self.cropped_windows = [
+            window for window in get_windows(
+                xmin=-self.padding,
+                ymin=-self.padding,
+                xmax=self.width + self.padding,
+                ymax=self.height + self.padding,
+                tile_width=self.tile_size - (padding * 2),
+                tile_height=self.tile_size - (padding * 2),
+                overlap=0,
+            )
+        ]
 
-	def __len__(self):
-		return len(self.cropped_windows)
+    def __len__(self):
+        return len(self.cropped_windows)
 
-	def __getitem__(self, idx):
-		cropped_window = self.cropped_windows[idx]
-		cropped_window_dict = {
-			'col_off': cropped_window.col_off,
-			'row_off': cropped_window.row_off,
-			'width': cropped_window.width,
-			'height': cropped_window.height,
-		}
-		inference_window = windows.Window(
-			cropped_window.col_off - self.padding,
-			cropped_window.row_off - self.padding,
-			cropped_window.width + (2 * self.padding),
-			cropped_window.height + (2 * self.padding),
-		)
-		image = self.image_src.read((1, 2, 3), window=inference_window)
+    def __getitem__(self, idx):
+        cropped_window = self.cropped_windows[idx]
+        cropped_window_dict = {
+            "col_off": cropped_window.col_off,
+            "row_off": cropped_window.row_off,
+            "width": cropped_window.width,
+            "height": cropped_window.height,
+        }
+        inference_window = windows.Window(
+            cropped_window.col_off - self.padding,
+            cropped_window.row_off - self.padding,
+            cropped_window.width + (2 * self.padding),
+            cropped_window.height + (2 * self.padding),
+        )
+        image = self.image_src.read((1, 2, 3), window=inference_window)
 
-		# enable boundless reads also for VRTs by adding padding of zeros if necessary
-		if image.shape[1] < self.tile_size or image.shape[2] < self.tile_size:
-			pad_left = 0 if inference_window.col_off >= 0 else abs(inference_window.col_off)
-			pad_right = self.tile_size - (pad_left + image.shape[2])
+        # enable boundless reads also for VRTs by adding padding of zeros if necessary
+        if image.shape[1] < self.tile_size or image.shape[2] < self.tile_size:
 
-			pad_top = 0 if inference_window.row_off >= 0 else abs(inference_window.row_off)
-			pad_bottom = self.tile_size - (pad_top + image.shape[1])
+            pad_left = 0 if inference_window.col_off >= 0 else abs(
+                inference_window.col_off)
+            pad_right = self.tile_size - (pad_left + image.shape[2])
 
-			image = np.pad(
-				image,
-				(
-					(0, 0),
-					(pad_top, pad_bottom),
-					(pad_left, pad_right),
-				),
-				mode='constant',
-				constant_values=0,
-			)
+            pad_top = 0 if inference_window.row_off >= 0 else abs(
+                inference_window.row_off)
+            pad_bottom = self.tile_size - (pad_top + image.shape[1])
 
-		# Reshape the image tensor to have 3 channels
-		image = image.transpose(1, 2, 0)
+            image = np.pad(
+                image,
+                (
+                    (0, 0),
+                    (pad_top, pad_bottom),
+                    (pad_left, pad_right),
+                ),
+                mode="constant",
+                constant_values=0,
+            )
 
-		image_transforms = transforms.Compose(
-			[
-				transforms.ToTensor(),
-				transforms.Normalize(
-					mean=[0.485, 0.456, 0.406],
-					std=[0.229, 0.224, 0.225],
-				),
-			]
-		)
-		image_tensor = image_transforms(image).float().contiguous()
-		return image_tensor, cropped_window_dict
+        # Reshape the image tensor to have 3 channels
+        image = image.transpose(1, 2, 0)
+
+        image_transforms = transforms.Compose([
+            transforms.ToTensor(),
+            transforms.Normalize(
+                mean=[0.485, 0.456, 0.406],
+                std=[0.229, 0.224, 0.225],
+            ),
+        ])
+        image_tensor = image_transforms(image).float().contiguous()
+        return image_tensor, cropped_window_dict
 
 
 def get_windows(xmin, ymin, xmax, ymax, tile_width, tile_height, overlap):
-	xstep = tile_width - overlap
-	ystep = tile_height - overlap
-	for x in range(xmin, xmax, xstep):
-		if x + tile_width > xmax:
-			x = xmax - tile_width
-		for y in range(ymin, ymax, ystep):
-			if y + tile_height > ymax:
-				y = ymax - tile_height
-			window = windows.Window(x, y, tile_width, tile_height)
-			yield window
+    xstep = tile_width - overlap
+    ystep = tile_height - overlap
+    for x in range(xmin, xmax, xstep):
+        if x + tile_width > xmax:
+            x = xmax - tile_width
+        for y in range(ymin, ymax, ystep):
+            if y + tile_height > ymax:
+                y = ymax - tile_height
+            window = windows.Window(x, y, tile_width, tile_height)
+            yield window

--- a/deadwood/InferenceDataset.py
+++ b/deadwood/InferenceDataset.py
@@ -19,10 +19,10 @@ class InferenceDataset(Dataset):
 		self.cropped_windows = [
 			window
 			for window in get_windows(
-				xmin=self.padding,
-				ymin=self.padding,
-				xmax=self.width - self.padding,
-				ymax=self.height - self.padding,
+				xmin=-self.padding,
+				ymin=-self.padding,
+				xmax=self.width + self.padding,
+				ymax=self.height + self.padding,
 				tile_width=self.tile_size - (padding * 2),
 				tile_height=self.tile_size - (padding * 2),
 				overlap=0,
@@ -31,28 +31,8 @@ class InferenceDataset(Dataset):
 
 	def __len__(self):
 		return len(self.cropped_windows)
-    def __init__(self, image_src, tile_size=512, padding=56):
-        super(InferenceDataset, self).__init__()
-        self.tile_size = tile_size
-        self.padding = padding
-        self.image_src = image_src
-        self.width = self.image_src.width
-        self.height = self.image_src.height
-
-        self.cropped_windows = [
-            window for window in get_windows(
-                xmin=-self.padding,
-                ymin=-self.padding,
-                xmax=self.width + self.padding,
-                ymax=self.height + self.padding,
-                tile_width=self.tile_size - (padding * 2),
-                tile_height=self.tile_size - (padding * 2),
-                overlap=0,
-            )
-        ]
 
 	def __getitem__(self, idx):
-		image_src = rasterio.open(self.image_path)
 		cropped_window = self.cropped_windows[idx]
 		cropped_window_dict = {
 			'col_off': cropped_window.col_off,
@@ -66,47 +46,29 @@ class InferenceDataset(Dataset):
 			cropped_window.width + (2 * self.padding),
 			cropped_window.height + (2 * self.padding),
 		)
-		image = image_src.read((1, 2, 3), window=inference_window)
+		image = self.image_src.read((1, 2, 3), window=inference_window)
+
+		# enable boundless reads also for VRTs by adding padding of zeros if necessary
+		if image.shape[1] < self.tile_size or image.shape[2] < self.tile_size:
+			pad_left = 0 if inference_window.col_off >= 0 else abs(inference_window.col_off)
+			pad_right = self.tile_size - (pad_left + image.shape[2])
+
+			pad_top = 0 if inference_window.row_off >= 0 else abs(inference_window.row_off)
+			pad_bottom = self.tile_size - (pad_top + image.shape[1])
+
+			image = np.pad(
+				image,
+				(
+					(0, 0),
+					(pad_top, pad_bottom),
+					(pad_left, pad_right),
+				),
+				mode='constant',
+				constant_values=0,
+			)
 
 		# Reshape the image tensor to have 3 channels
 		image = image.transpose(1, 2, 0)
-    def __getitem__(self, idx):
-        cropped_window = self.cropped_windows[idx]
-        cropped_window_dict = {
-            "col_off": cropped_window.col_off,
-            "row_off": cropped_window.row_off,
-            "width": cropped_window.width,
-            "height": cropped_window.height,
-        }
-        inference_window = windows.Window(
-            cropped_window.col_off - self.padding,
-            cropped_window.row_off - self.padding,
-            cropped_window.width + (2 * self.padding),
-            cropped_window.height + (2 * self.padding),
-        )
-        image = self.image_src.read((1, 2, 3), window=inference_window)
-
-        # enable boundless reads also for VRTs by adding padding of zeros if necessary
-        if image.shape[1] < self.tile_size or image.shape[2] < self.tile_size:
-
-            pad_left = 0 if inference_window.col_off >= 0 else abs(
-                inference_window.col_off)
-            pad_right = self.tile_size - (pad_left + image.shape[2])
-
-            pad_top = 0 if inference_window.row_off >= 0 else abs(
-                inference_window.row_off)
-            pad_bottom = self.tile_size - (pad_top + image.shape[1])
-
-            image = np.pad(
-                image,
-                (
-                    (0, 0),
-                    (pad_top, pad_bottom),
-                    (pad_left, pad_right),
-                ),
-                mode="constant",
-                constant_values=0,
-            )
 
 		image_transforms = transforms.Compose(
 			[

--- a/deadwood/deadwood_inference.py
+++ b/deadwood/deadwood_inference.py
@@ -16,6 +16,7 @@ from ..common import mask_to_polygons, filter_polygons_by_area, reproject_polygo
 
 class DeadwoodInference:
     
+
     def __init__(self, config_path: str, model_path: str):
 
         # set float32 matmul precision for higher performance

--- a/deadwood/deadwood_inference.py
+++ b/deadwood/deadwood_inference.py
@@ -62,8 +62,8 @@ class DeadwoodInference:
                 torch.save(model.state_dict(), str(cache_path))
 
             # Disabled torch.compile due to Python 3.12.3 compatibility constraints. The feature is not supported in the current PyTorch version used in the TCD conda environment.
-            # model = torch.compile(model)
-            # safetensors.torch.load_model(model, self.model_path)
+            model = torch.compile(model)
+            safetensors.torch.load_model(model, self.model_path)
             model = model.to(memory_format=torch.channels_last, device=self.device)
             model.eval()
 

--- a/deadwood/deadwood_inference.py
+++ b/deadwood/deadwood_inference.py
@@ -25,7 +25,8 @@ class DeadwoodInference:
 
         self.model_path = model_path
         self.model = None
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = torch.device(
+            "cuda" if torch.cuda.is_available() else "cpu")
 
         self.load_model()
 

--- a/deadwood/deadwood_inference.py
+++ b/deadwood/deadwood_inference.py
@@ -1,187 +1,189 @@
 import torch
-import rasterio
 from torchvision.transforms.functional import crop
 import json
+from os.path import join
 import safetensors.torch
 import segmentation_models_pytorch as smp
 from pathlib import Path
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 import numpy as np
+import rasterio
 
 from .InferenceDataset import InferenceDataset
 from ..common import mask_to_polygons, filter_polygons_by_area, reproject_polygons, image_reprojector
 
 
 class DeadwoodInference:
-	def __init__(self, config_path: str, model_path: str):
-		# set float32 matmul precision for higher performance
-		torch.set_float32_matmul_precision('high')
+    
+    def __init__(self, config_path: str, model_path: str):
+        # set float32 matmul precision for higher performance
+        torch.set_float32_matmul_precision('high')
 
-		self.model_path = model_path
-		self.model = None
-		self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        with open(config_path, 'r') as f:
+            self.config = json.load(f)
 
-		with open(config_path, 'r') as f:
-			self.config = json.load(f)
+        self.model_path = model_path
+        self.model = None
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-		self.load_model()
+        self.load_model()
 
-	def get_cache_path(self):
-		model_path = Path(self.model_path)
-		return model_path.parent / f'{self.config["model_name"]}_pretrained.pt'
+    def get_cache_path(self):
+        model_path = Path(self.model_path)
+        return model_path.parent / f'{self.config["model_name"]}_pretrained.pt'
 
-	def load_model(self):
-		if 'segformer_b5' not in self.config['model_name']:
-			print('Invalid model name: ', self.config['model_name'], 'Exiting...')
-			exit()
+    def load_model(self):
+        if "segformer_b5" in self.config["model_name"]:
+            cache_path = self.get_cache_path()
 
-		cache_path = self.get_cache_path()
+            # Try to load from cache first
+            if cache_path.exists():
+                model = smp.Unet(
+                    encoder_name="mit_b5",
+                    encoder_weights=None,  # Don't load pretrained weights
+                    in_channels=3,
+                    classes=1,
+                ).to(memory_format=torch.channels_last)
 
-		# Try to load from cache first
-		if cache_path.exists():
-			model = smp.Unet(
-				encoder_name='mit_b5',
-				encoder_weights=None,  # Don't load pretrained weights
-				in_channels=3,
-				classes=1,
-			).to(memory_format=torch.channels_last)
+                model.load_state_dict(torch.load(str(cache_path)))
+            else:
+                # Load with pretrained weights and cache
+                model = smp.Unet(
+                    encoder_name="mit_b5",
+                    encoder_weights="imagenet",
+                    in_channels=3,
+                    classes=1,
+                ).to(memory_format=torch.channels_last)
 
-			model.load_state_dict(torch.load(str(cache_path)))
-		else:
-			# Load with pretrained weights and cache
-			model = smp.Unet(
-				encoder_name='mit_b5',
-				encoder_weights='imagenet',
-				in_channels=3,
-				classes=1,
-			).to(memory_format=torch.channels_last)
+                torch.save(model.state_dict(), str(cache_path))
 
-			torch.save(model.state_dict(), str(cache_path))
+            # Apply final model preparations
+            model = torch.compile(model)
+            safetensors.torch.load_model(model, self.model_path)
+            model = model.to(memory_format=torch.channels_last, device=self.device)
+            model.eval()
 
-		# Apply final model preparations
-		model = torch.compile(model)
-		safetensors.torch.load_model(model, self.model_path)
-		model = model.to(memory_format=torch.channels_last, device=self.device)
-		model.eval()
+            self.model = model
+        else:
+            print("Invalid model name: ", self.config["model_name"], "Exiting...")
+            exit()
 
-		self.model = model
+    def inference_deadwood(self, input_tif):
+        """
+        gets path to tif file and returns polygons of deadwood in the CRS of the tif
+        """
 
-	def inference_deadwood(self, input_tif):
-		"""
-		gets path to tif file and returns polygons of deadwood in the CRS of the tif
-		"""
+        # will always return a memory file, also when not reprojecting
+        reprojected_mem_file = image_reprojector(
+            input_tif, min_res=self.config['deadwood_minimum_inference_resolution']
+        )
 
-		# will always return a memory file, also when not reprojecting
-		reprojected_mem_file = image_reprojector(
-			input_tif, min_res=self.config['deadwood_minimum_inference_resolution']
-		)
+        dataset = InferenceDataset(image_path=reprojected_mem_file, tile_size=1024, padding=256)
+        vrt_src = dataset.image_src  # Store reference to the image source
 
-		dataset = InferenceDataset(image_path=reprojected_mem_file, tile_size=1024, padding=256)
-		vrt_src = dataset.image_src  # Store reference to the image source
+        loader_args = {
+            'batch_size': self.config['batch_size'],
+            'num_workers': self.config['num_dataloader_workers'],
+            'pin_memory': True,
+            'shuffle': False,
+        }
+        inference_loader = DataLoader(dataset, **loader_args)
 
-		loader_args = {
-			'batch_size': self.config['batch_size'],
-			'num_workers': self.config['num_dataloader_workers'],
-			'pin_memory': True,
-			'shuffle': False,
-		}
-		inference_loader = DataLoader(dataset, **loader_args)
+        outimage = np.zeros((dataset.height, dataset.width), dtype=np.float32)
+        for images, cropped_windows in tqdm(inference_loader, desc='inference'):
+            images = images.to(device=self.device, memory_format=torch.channels_last)
 
-		outimage = np.zeros((dataset.height, dataset.width), dtype=np.float32)
-		for images, cropped_windows in tqdm(inference_loader, desc='inference'):
-			images = images.to(device=self.device, memory_format=torch.channels_last)
+            output = None
+            with torch.no_grad():
+                # if the the batch size is smaller than the configured batch size, apply padding
+                if images.shape[0] < self.config['batch_size']:
+                    pad = torch.zeros((self.config['batch_size'], 3, 1024, 1024), dtype=torch.float32)
+                    pad[: images.shape[0]] = images
+                    # move to device
+                    pad = pad.to(device=self.device, memory_format=torch.channels_last)
+                    output = self.model(pad)
+                    output = output[: images.shape[0]]
+                else:
+                    output = self.model(images)
 
-			output = None
-			with torch.no_grad():
-				# if the the batch size is smaller than the configured batch size, apply padding
-				if images.shape[0] < self.config['batch_size']:
-					pad = torch.zeros((self.config['batch_size'], 3, 1024, 1024), dtype=torch.float32)
-					pad[: images.shape[0]] = images
-					# move to device
-					pad = pad.to(device=self.device, memory_format=torch.channels_last)
-					output = self.model(pad)
-					output = output[: images.shape[0]]
-				else:
-					output = self.model(images)
+                output = torch.sigmoid(output)
 
-				output = torch.sigmoid(output)
+            # go through batch and save to output
+            for i in range(output.shape[0]):
+                output_tile = output[i].cpu()
 
-			# go through batch and save to output
-			for i in range(output.shape[0]):
-				output_tile = output[i].cpu()
+                # crop tensor by dataset padding
+                output_tile = crop(
+                    output_tile,
+                    top=dataset.padding,
+                    left=dataset.padding,
+                    height=dataset.tile_size - (2 * dataset.padding),
+                    width=dataset.tile_size - (2 * dataset.padding),
+                )
 
-				# crop tensor by dataset padding
-				output_tile = crop(
-					output_tile,
-					top=dataset.padding,
-					left=dataset.padding,
-					height=dataset.tile_size - (2 * dataset.padding),
-					width=dataset.tile_size - (2 * dataset.padding),
-				)
+                # derive min/max from cropped window
+                minx = cropped_windows['col_off'][i]
+                maxx = minx + cropped_windows['width'][i]
+                miny = cropped_windows['row_off'][i]
+                maxy = miny + cropped_windows['width'][i]
 
-				# derive min/max from cropped window
-				minx = cropped_windows['col_off'][i]
-				maxx = minx + cropped_windows['width'][i]
-				miny = cropped_windows['row_off'][i]
-				maxy = miny + cropped_windows['width'][i]
+                # clip to positive values when writing and also to the image size
+                diff_minx = 0
+                if minx < 0:
+                    diff_minx = abs(minx)
+                    minx = 0
 
-				# clip to positive values when writing and also to the image size
-				diff_minx = 0
-				if minx < 0:
-					diff_minx = abs(minx)
-					minx = 0
+                diff_miny = 0
+                if miny < 0:
+                    diff_miny = abs(miny)
+                    miny = 0
 
-				diff_miny = 0
-				if miny < 0:
-					diff_miny = abs(miny)
-					miny = 0
+                diff_maxx = 0
+                if maxx > outimage.shape[1]:
+                    diff_maxx = maxx - outimage.shape[1]
+                    maxx = outimage.shape[1]
 
-				diff_maxx = 0
-				if maxx > outimage.shape[1]:
-					diff_maxx = maxx - outimage.shape[1]
-					maxx = outimage.shape[1]
+                diff_maxy = 0
+                if maxy > outimage.shape[0]:
+                    diff_maxy = maxy - outimage.shape[0]
+                    maxy = outimage.shape[0]
 
-				diff_maxy = 0
-				if maxy > outimage.shape[0]:
-					diff_maxy = maxy - outimage.shape[0]
-					maxy = outimage.shape[0]
+                # crop output tile to the correct size
+                output_tile = output_tile[
+                    :, diff_miny : output_tile.shape[1] - diff_maxy, diff_minx : output_tile.shape[2] - diff_maxx
+                ]
 
-				# crop output tile to the correct size
-				output_tile = output_tile[
-					:, diff_miny : output_tile.shape[1] - diff_maxy, diff_minx : output_tile.shape[2] - diff_maxx
-				]
+                # save tile to output array
+                outimage[miny:maxy, minx:maxx] = output_tile[0].numpy()
 
-				# save tile to output array
-				outimage[miny:maxy, minx:maxx] = output_tile[0].numpy()
+        print('Postprocessing mask into polygons and filtering....')
 
-		print('Postprocessing mask into polygons and filtering....')
+        reprojected_mem_file.close()
 
-		reprojected_mem_file.close()
+        # threshold the output image
+        outimage = (outimage > self.config['probabilty_threshold']).astype(np.uint8)
 
-		# threshold the output image
-		outimage = (outimage > self.config['probabilty_threshold']).astype(np.uint8)
+        # get nodata mask
+        nodata_mask = vrt_src.dataset_mask() == 255
 
-		# get nodata mask
-		nodata_mask = vrt_src.dataset_mask() == 255
+        # mask out nodata in predictions
+        outimage[~nodata_mask] = 0
 
-		# mask out nodata in predictions
-		outimage[~nodata_mask] = 0
+        # get polygons from mask
+        if outimage.sum() == 0:
+            return None
 
-		# get polygons from mask
-		if outimage.sum() == 0:
-			return None
+        polygons = mask_to_polygons(outimage, vrt_src)
 
-		polygons = mask_to_polygons(outimage, vrt_src)
+        # close the vrt
+        vrt_src.close()
 
-		# close the vrt
-		vrt_src.close()
+        polygons = filter_polygons_by_area(polygons, self.config['minimum_polygon_area'])
 
-		polygons = filter_polygons_by_area(polygons, self.config['minimum_polygon_area'])
+        # reproject the polygons back into the crs of the input tif
+        polygons = reproject_polygons(polygons, dataset.image_src.crs, rasterio.open(input_tif).crs)
 
-		# reproject the polygons back into the crs of the input tif
-		polygons = reproject_polygons(polygons, dataset.image_src.crs, rasterio.open(input_tif).crs)
+        print('done')
 
-		print('done')
-
-		return polygons
+        return polygons

--- a/deadwood/deadwood_inference.py
+++ b/deadwood/deadwood_inference.py
@@ -15,7 +15,7 @@ from ..common import mask_to_polygons, filter_polygons_by_area, reproject_polygo
 
 
 class DeadwoodInference:
-    
+
 
     def __init__(self, config_path: str, model_path: str):
 
@@ -54,7 +54,7 @@ class DeadwoodInference:
                 # Load with pretrained weights and cache
                 model = smp.Unet(
                     encoder_name="mit_b5",
-                    encoder_weights="imagenet",
+                    encoder_weights=None,
                     in_channels=3,
                     classes=1,
                 ).to(memory_format=torch.channels_last)

--- a/deadwood/deadwood_inference.py
+++ b/deadwood/deadwood_inference.py
@@ -177,11 +177,12 @@ class DeadwoodInference:
         outimage = (outimage
                     > self.config["probabilty_threshold"]).astype(np.uint8)
 
-        # get nodata mask
-        nodata_mask = (vrt_src.dataset_mask() == 255)
+        # remove no data handling since its done in standardise_geotif, also caused errors like https://github.com/Deadwood-ai/deadtrees/issues/127
+		# get nodata mask
+        # nodata_mask = (vrt_src.dataset_mask() == 255)
 
         # mask out nodata in predictions
-        outimage[~nodata_mask] = 0
+        #outimage[~nodata_mask] = 0
 
         # get polygons from mask
         polygons = mask_to_polygons(outimage, dataset.image_src)

--- a/deadwood/deadwood_inference.py
+++ b/deadwood/deadwood_inference.py
@@ -61,9 +61,9 @@ class DeadwoodInference:
 
                 torch.save(model.state_dict(), str(cache_path))
 
-            # Apply final model preparations
-            model = torch.compile(model)
-            safetensors.torch.load_model(model, self.model_path)
+            # Disabled torch.compile due to Python 3.12.3 compatibility constraints. The feature is not supported in the current PyTorch version used in the TCD conda environment.
+            # model = torch.compile(model)
+            # safetensors.torch.load_model(model, self.model_path)
             model = model.to(memory_format=torch.channels_last, device=self.device)
             model.eval()
 

--- a/deadwood/deadwood_inference.py
+++ b/deadwood/deadwood_inference.py
@@ -1,9 +1,10 @@
+import rasterio
 import torch
 from torchvision.transforms.functional import crop
 import json
 from os.path import join
 import safetensors.torch
-from common import *
+from ..common import mask_to_polygons, filter_polygons_by_area, reproject_polygons, image_reprojector
 from .InferenceDataset import InferenceDataset
 import segmentation_models_pytorch as smp
 from pathlib import Path
@@ -12,122 +13,127 @@ from tqdm import tqdm
 import numpy as np
 
 
-class DeadwoodInference():
+class DeadwoodInference:
+	def __init__(self, config_path):
+		with open(config_path, 'r') as f:
+			self.config = json.load(f)
 
-    def __init__(self, config_path):
+		self.model = None
+		self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
-        with open(config_path, 'r') as f:
-            self.config = json.load(f)
+		self.load_model()
 
-        self.model = None
-        self.device = torch.device(
-            "cuda" if torch.cuda.is_available() else "cpu")
+	def get_cache_path(self):
+		model_path = Path(self.config['model_path'])
+		return model_path.parent / f"{self.config['model_name']}_pretrained.pt"
 
-        self.load_model()
+	def load_model(self):
+		if 'segformer_b5' not in self.config['model_name']:
+			print('Invalid model name: ', self.config['model_name'], 'Exiting...')
+			exit()
 
-    def load_model(self):
+		cache_path = self.get_cache_path()
 
-        if "segformer_b5" in self.config["model_name"]:
-            model = smp.Unet(
-                encoder_name="mit_b5",
-                encoder_weights="imagenet",
-                in_channels=3,
-                classes=1,
-            ).to(memory_format=torch.channels_last)
+		# Try to load from cache first
+		if cache_path.exists():
+			model = smp.Unet(
+				encoder_name='mit_b5',
+				encoder_weights=None,  # Don't load pretrained weights
+				in_channels=3,
+				classes=1,
+			).to(memory_format=torch.channels_last)
 
-            model = torch.compile(model)
-            safetensors.torch.load_model(
-                model,
-                join(str(Path(__file__).parent.parent), "data",
-                     self.config["model_name"] + ".safetensors"))
-            # model = nn.DataParallel(model)
-            model = model.to(memory_format=torch.channels_last,
-                             device=self.device)
+			model.load_state_dict(torch.load(str(cache_path)))
+		else:
+			# Load with pretrained weights and cache
+			model = smp.Unet(
+				encoder_name='mit_b5',
+				encoder_weights='imagenet',
+				in_channels=3,
+				classes=1,
+			).to(memory_format=torch.channels_last)
 
-            model.eval()
+			torch.save(model.state_dict(), str(cache_path))
 
-            self.model = model
+		# Apply final model preparations
+		model = torch.compile(model)
+		safetensors.torch.load_model(model, self.config['model_path'])
+		model = model.to(memory_format=torch.channels_last, device=self.device)
+		model.eval()
 
-        else:
-            print("Invalid model name: ", self.config["model_name"],
-                  "Exiting...")
-            exit()
+		self.model = model
 
-    def inference_deadwood(self, input_tif):
-        """
-        gets path to tif file and returns polygons of deadwood in the CRS of the tif
-        """
+	def inference_deadwood(self, input_tif):
+		"""
+		gets path to tif file and returns polygons of deadwood in the CRS of the tif
+		"""
 
-        # will always return a memory file, also when not reprojecting
-        reprojected_mem_file = image_reprojector(
-            input_tif,
-            min_res=self.config["deadwood_minimum_inference_resolution"])
+		# will always return a memory file, also when not reprojecting
+		reprojected_mem_file = image_reprojector(
+			input_tif, min_res=self.config['deadwood_minimum_inference_resolution']
+		)
 
-        dataset = InferenceDataset(image_path=reprojected_mem_file,
-                                   tile_size=1024,
-                                   padding=256)
+		dataset = InferenceDataset(image_path=reprojected_mem_file, tile_size=1024, padding=256)
 
-        loader_args = {
-            "batch_size": self.config["batch_size"],
-            "num_workers": self.config["num_dataloader_workers"],
-            "pin_memory": True,
-            "shuffle": False,
-        }
-        inference_loader = DataLoader(dataset, **loader_args)
+		loader_args = {
+			'batch_size': self.config['batch_size'],
+			'num_workers': self.config['num_dataloader_workers'],
+			'pin_memory': True,
+			'shuffle': False,
+		}
+		inference_loader = DataLoader(dataset, **loader_args)
 
-        outimage = np.zeros((dataset.height, dataset.width), dtype=np.float32)
-        for images, cropped_windows in tqdm(inference_loader,
-                                            desc="inference"):
-            images = images.to(device=self.device,
-                               memory_format=torch.channels_last)
+		outimage = np.zeros((dataset.height, dataset.width), dtype=np.float32)
+		for images, cropped_windows in tqdm(inference_loader, desc='inference'):
+			images = images.to(device=self.device, memory_format=torch.channels_last)
 
-            output = None
-            with torch.no_grad():
-                output = self.model(images)
-                output = torch.sigmoid(output)
+			output = None
+			with torch.no_grad():
+				output = self.model(images)
+				output = torch.sigmoid(output)
 
-            # go through batch and save to output
-            for i in range(output.shape[0]):
-                output_tile = output[i]
+			# go through batch and save to output
+			for i in range(output.shape[0]):
+				output_tile = output[i]
 
-                # crop tensor by dataset padding
-                output_tile = crop(
-                    output_tile,
-                    top=dataset.padding,
-                    left=dataset.padding,
-                    height=dataset.tile_size - (2 * dataset.padding),
-                    width=dataset.tile_size - (2 * dataset.padding),
-                )
+				# crop tensor by dataset padding
+				output_tile = crop(
+					output_tile,
+					top=dataset.padding,
+					left=dataset.padding,
+					height=dataset.tile_size - (2 * dataset.padding),
+					width=dataset.tile_size - (2 * dataset.padding),
+				)
 
-                # derive min/max from cropped window
-                minx = cropped_windows["col_off"][i]
-                maxx = minx + cropped_windows["width"][i]
-                miny = cropped_windows["row_off"][i]
-                maxy = miny + cropped_windows["width"][i]
+				# derive min/max from cropped window
+				minx = cropped_windows['col_off'][i]
+				maxx = minx + cropped_windows['width'][i]
+				miny = cropped_windows['row_off'][i]
+				maxy = miny + cropped_windows['width'][i]
 
-                # save tile to output array
-                outimage[miny:maxy, minx:maxx] = output_tile[0].cpu().numpy()
+				# save tile to output array
+				outimage[miny:maxy, minx:maxx] = output_tile[0].cpu().numpy()
 
-        reprojected_mem_file.close()
+		reprojected_mem_file.close()
 
-        # threshold the output image
-        outimage = (outimage
-                    > self.config["probabilty_threshold"]).astype(np.uint8)
+		# threshold the output image
+		outimage = (outimage > self.config['probabilty_threshold']).astype(np.uint8)
 
-        # get nodata mask
-        nodata_mask = dataset.image_src.read_masks(
-        )[0] == dataset.image_src.nodata
+		# get nodata mask
+		nodata_mask = dataset.image_src.read_masks()[0] == dataset.image_src.nodata
 
-        # mask out nodata in predictions
-        outimage[nodata_mask] = 0
+		# mask out nodata in predictions
+		outimage[nodata_mask] = 0
 
-        # get polygons from mask
-        polygons = mask_to_polygons(outimage, dataset.image_src)
+		# get polygons from mask
+		if outimage.sum() == 0:
+			return None
 
-        polygons = filter_polygons_by_area(polygons, self.config["minimum_polygon_area"])
+		polygons = mask_to_polygons(outimage, dataset.image_src)
 
-        # reproject the polygons back into the crs of the input tif
-        polygons = reproject_polygons(polygons, dataset.image_src.crs,
-                           rasterio.open(input_tif).crs)
+		polygons = filter_polygons_by_area(polygons, self.config['minimum_polygon_area'])
 
-        return polygons
+		# reproject the polygons back into the crs of the input tif
+		polygons = reproject_polygons(polygons, dataset.image_src.crs, rasterio.open(input_tif).crs)
+
+		return polygons

--- a/deadwood/deadwood_inference.py
+++ b/deadwood/deadwood_inference.py
@@ -14,18 +14,19 @@ import numpy as np
 
 
 class DeadwoodInference:
-	def __init__(self, config_path):
+	def __init__(self, config_path: str, model_path: str):
 		with open(config_path, 'r') as f:
 			self.config = json.load(f)
 
+		self.model_path = model_path
 		self.model = None
 		self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 		self.load_model()
 
 	def get_cache_path(self):
-		model_path = Path(self.config['model_path'])
-		return model_path.parent / f"{self.config['model_name']}_pretrained.pt"
+		model_path = Path(self.model_path)
+		return model_path.parent / f'{self.config["model_name"]}_pretrained.pt'
 
 	def load_model(self):
 		if 'segformer_b5' not in self.config['model_name']:
@@ -57,7 +58,7 @@ class DeadwoodInference:
 
 		# Apply final model preparations
 		model = torch.compile(model)
-		safetensors.torch.load_model(model, self.config['model_path'])
+		safetensors.torch.load_model(model, self.model_path)
 		model = model.to(memory_format=torch.channels_last, device=self.device)
 		model.eval()
 

--- a/deadwood/deadwood_inference.py
+++ b/deadwood/deadwood_inference.py
@@ -62,7 +62,7 @@ class DeadwoodInference:
                 torch.save(model.state_dict(), str(cache_path))
 
             # Disabled torch.compile due to Python 3.12.3 compatibility constraints. The feature is not supported in the current PyTorch version used in the TCD conda environment.
-            model = torch.compile(model)
+            model = torch.compile(model, backend='aot_eager')
             safetensors.torch.load_model(model, self.model_path)
             model = model.to(memory_format=torch.channels_last, device=self.device)
             model.eval()

--- a/deadwood/deadwood_inference.py
+++ b/deadwood/deadwood_inference.py
@@ -17,14 +17,15 @@ from ..common import mask_to_polygons, filter_polygons_by_area, reproject_polygo
 class DeadwoodInference:
     
     def __init__(self, config_path: str, model_path: str):
+
         # set float32 matmul precision for higher performance
         torch.set_float32_matmul_precision('high')
 
         with open(config_path, 'r') as f:
             self.config = json.load(f)
 
-        self.model_path = model_path
         self.model = None
+        self.model_path = model_path
         self.device = torch.device(
             "cuda" if torch.cuda.is_available() else "cpu")
 

--- a/deadwood/deadwood_inference.py
+++ b/deadwood/deadwood_inference.py
@@ -1,16 +1,16 @@
-import rasterio
 import torch
+import rasterio
 from torchvision.transforms.functional import crop
 import json
-from os.path import join
 import safetensors.torch
-from ..common import mask_to_polygons, filter_polygons_by_area, reproject_polygons, image_reprojector
-from .InferenceDataset import InferenceDataset
 import segmentation_models_pytorch as smp
 from pathlib import Path
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 import numpy as np
+
+from .InferenceDataset import InferenceDataset
+from ..common import mask_to_polygons, filter_polygons_by_area, reproject_polygons, image_reprojector
 
 
 class DeadwoodInference:

--- a/deadwood/deadwood_inference.py
+++ b/deadwood/deadwood_inference.py
@@ -28,34 +28,19 @@ class DeadwoodInference:
 
 		self.load_model()
 
-	def get_cache_path(self):
-		model_path = Path(self.model_path)
-		return model_path.parent / f'{self.config["model_name"]}_pretrained.pt'
-
 	def load_model(self):
 		if 'segformer_b5' in self.config['model_name']:
 			cache_path = self.get_cache_path()
 
 			# Try to load from cache first
-			if cache_path.exists():
-				model = smp.Unet(
-					encoder_name='mit_b5',
-					encoder_weights=None,  # Don't load pretrained weights
-					in_channels=3,
-					classes=1,
-				).to(memory_format=torch.channels_last)
+			model = smp.Unet(
+				encoder_name='mit_b5',
+				encoder_weights=None,  # Don't load pretrained weights
+				in_channels=3,
+				classes=1,
+			).to(memory_format=torch.channels_last)
 
-				model.load_state_dict(torch.load(str(cache_path)))
-			else:
-				# Load with pretrained weights and cache
-				model = smp.Unet(
-					encoder_name='mit_b5',
-					encoder_weights=None,
-					in_channels=3,
-					classes=1,
-				).to(memory_format=torch.channels_last)
-
-				torch.save(model.state_dict(), str(cache_path))
+			model.load_state_dict(torch.load(self.model_path))
 
 			model = torch.compile(model, backend='aot_eager')
 			safetensors.torch.load_model(model, self.model_path)

--- a/deadwood_inference_config.json
+++ b/deadwood_inference_config.json
@@ -3,8 +3,7 @@
     "probabilty_threshold": 0.5,
     "deadwood_minimum_inference_resolution": 0.05,
     "model_name": "segformer_b5_full_epoch_100",
-    "batch_size": 1,
-    "num_workers": 0,
+    "batch_size": 2,
     "num_dataloader_workers": 1,
     "minimum_polygon_area": 0.1
 }

--- a/deadwood_inference_config.json
+++ b/deadwood_inference_config.json
@@ -1,11 +1,10 @@
 {
-  "config_name": "deadwood_default_14_Feb_2025",
+  "config_name": "deadwood_default_08_Jan_2025",
   "probabilty_threshold": 0.5,
   "deadwood_minimum_inference_resolution": 0.05,
   "model_name": "segformer_b5_full_epoch_100",
-  "device": "cuda",
   "batch_size": 1,
   "num_workers": 0,
-  "num_dataloader_workers": 2,
+  "num_dataloader_workers": 1,
   "minimum_polygon_area": 0.1
 }

--- a/deadwood_inference_config.json
+++ b/deadwood_inference_config.json
@@ -1,8 +1,8 @@
 {
-  "config_name": "deadwood_default_08_Jan_2025",
+  "config_name": "deadwood_default_14_Feb_2025",
   "probabilty_threshold": 0.5,
   "deadwood_minimum_inference_resolution": 0.05,
-  "model_name": "segformer_b5_fold_0_epoch_74",
+  "model_name": "segformer_b5_full_epoch_100",
   "device": "cuda",
   "batch_size": 1,
   "num_workers": 0,

--- a/deadwood_inference_config.json
+++ b/deadwood_inference_config.json
@@ -1,9 +1,12 @@
 {
-    "config_name": "deadwood_default_08_Jan_2025",
-    "probabilty_threshold": 0.5,
-    "deadwood_minimum_inference_resolution": 0.05,
-    "model_name": "segformer_b5_fold_0_epoch_74",
-    "batch_size": 16,
-    "num_dataloader_workers": 2,
-    "minimum_polygon_area": 0.1
+  "config_name": "deadwood_default_08_Jan_2025",
+  "probabilty_threshold": 0.5,
+  "deadwood_minimum_inference_resolution": 0.05,
+  "model_name": "segformer_b5_fold_0_epoch_74",
+  "model_path": "/app/processor/src/deadwood_segmentation/models/segformer_b5_fold_0_epoch_74.safetensors",
+  "device": "cuda",
+  "batch_size": 1,
+  "num_workers": 0,
+  "num_dataloader_workers": 2,
+  "minimum_polygon_area": 0.1
 }

--- a/deadwood_inference_config.json
+++ b/deadwood_inference_config.json
@@ -1,10 +1,10 @@
 {
-  "config_name": "deadwood_default_08_Jan_2025",
-  "probabilty_threshold": 0.5,
-  "deadwood_minimum_inference_resolution": 0.05,
-  "model_name": "segformer_b5_full_epoch_100",
-  "batch_size": 1,
-  "num_workers": 0,
-  "num_dataloader_workers": 1,
-  "minimum_polygon_area": 0.1
+    "config_name": "deadwood_default_08_Jan_2025",
+    "probabilty_threshold": 0.5,
+    "deadwood_minimum_inference_resolution": 0.05,
+    "model_name": "segformer_b5_full_epoch_100",
+    "batch_size": 1,
+    "num_workers": 0,
+    "num_dataloader_workers": 1,
+    "minimum_polygon_area": 0.1
 }

--- a/deadwood_inference_config.json
+++ b/deadwood_inference_config.json
@@ -3,7 +3,6 @@
   "probabilty_threshold": 0.5,
   "deadwood_minimum_inference_resolution": 0.05,
   "model_name": "segformer_b5_fold_0_epoch_74",
-  "model_path": "/app/processor/src/deadwood_segmentation/models/segformer_b5_fold_0_epoch_74.safetensors",
   "device": "cuda",
   "batch_size": 1,
   "num_workers": 0,

--- a/infer_ortho.py
+++ b/infer_ortho.py
@@ -2,8 +2,8 @@ from deadwood.deadwood_inference import DeadwoodInference
 import rasterio
 from common.common import *
 
-filename = "/scratch/cmosig/test_image_seg/20211001_FVA_Walddrohnen_Totholz_3_ortho.tif"
+filename = '/scratch/cmosig/test_image_seg/20211001_FVA_Walddrohnen_Totholz_3_ortho.tif'
 
-deadwodinference = DeadwoodInference(config_path="deadwood_inference_config.json")
+deadwodinference = DeadwoodInference(config_path='deadwood_inference_config.json')
 polygons = deadwodinference.inference_deadwood(filename)
-save_poly("deadwood_test.gpkg", polygons, crs=rasterio.open(filename).crs)
+save_poly('deadwood_test.gpkg', polygons, crs=rasterio.open(filename).crs)

--- a/infer_ortho_batch.py
+++ b/infer_ortho_batch.py
@@ -7,24 +7,21 @@ import os
 pathlist = sys.argv[1]
 
 deadwodinference = DeadwoodInference(
-    config_path=
-    "/net/home/cmosig/projects/deadtreesmodels/deadwood_inference_config.json")
+	config_path='/net/home/cmosig/projects/deadtreesmodels/deadwood_inference_config.json'
+)
 
 with open(pathlist) as f:
-    files = f.readlines()
+	files = f.readlines()
 
-    for filename in files:
-        print("processing", filename)
-        f = filename.strip()
+	for filename in files:
+		print('processing', filename)
+		f = filename.strip()
 
-        outpath = f.split("/")[-1].replace(".tif", "_prediction.gpkg")
+		outpath = f.split('/')[-1].replace('.tif', '_prediction.gpkg')
 
-        if os.path.exists(outpath):
-            print("skipping", filename)
-            continue
+		if os.path.exists(outpath):
+			print('skipping', filename)
+			continue
 
-
-        polygons = deadwodinference.inference_deadwood(f)
-        save_poly(outpath,
-                  polygons,
-                  crs=rasterio.open(f).crs)
+		polygons = deadwodinference.inference_deadwood(f)
+		save_poly(outpath, polygons, crs=rasterio.open(f).crs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.format]
+quote-style = "single"
+indent-style = "tab"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,17 @@
-geopandas==0.14.4
-numpy==2.2.1
-opencv_python_headless==4.10.0.84
-rasterio==1.4.3
-safetensors==0.5.2
-segmentation_models_pytorch==0.3.3
-Shapely==2.0.6
-torch==2.4.1
-torchvision==0.19.1
-tqdm==4.66.4
-utm==0.7.0
+# Core ML dependencies
+torch
+torchvision
+segmentation_models_pytorch
+safetensors
+
+# Data processing
+numpy
+opencv_python_headless
+Pillow
+rasterio
+Shapely
+geopandas
+
+# Utilities
+tqdm
+utm

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,6 @@ geopandas
 # Utilities
 tqdm
 utm
+
+# Code formatting
+ruff

--- a/tileinference.py
+++ b/tileinference.py
@@ -6,7 +6,6 @@ from torch.utils.data import DataLoader
 from unet_model import UNet
 from torchvision.transforms.functional import crop
 import os
-from pathlib import Path
 
 import geopandas as gpd
 import numpy as np
@@ -18,16 +17,14 @@ from shapely.geometry import Polygon, MultiPolygon
 
 # DEADWOOD_MODEL_PATH = "/net/scratch/cmosig/model.safetensors"
 # DEADWOOD_MODEL_PATH = "/net/scratch/jmoehring/checkpoints/3d_18k_100e_vanilla_tversky_a01b09g2/fold_0_epoch_99/model.safetensors"
-DEADWOOD_MODEL_PATH = str(
-	Path(__file__).parent.parent.parent.parent.parent / 'assets' / 'models' / 'segformer_b5_fold_0_epoch_74.safetensors'
-)
+DEADWOOD_MODEL_PATH = "/net/scratch/cmosig/experiment_dir_deadwood_segmentation/segformer_b5_oversample_newdata/fold_0_epoch_74/model.safetensors"
 
-# pathtotile = sys.argv[1]
-pathtotile = '/net/scratch/jmoehring/tiles/spain_20_09_2023_south_tejeda_1_ortho/0.08/1588_4484.tif'
+# pathtotile = sys.argv[1]    
+pathtotile = "/net/scratch/jmoehring/tiles/spain_20_09_2023_south_tejeda_1_ortho/0.08/1588_4484.tif"
 # pathtotile = "/net/scratch/jmoehring/tiles/spain_20_09_2023_south_tejeda_1_ortho/0.08/1588_900.tif"
 
 # preferably use GPU
-device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 # model with three input channels (RGB)
 # model = UNet(
@@ -36,10 +33,10 @@ device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 # ).to(memory_format=torch.channels_last)
 
 model = smp.Unet(
-	encoder_name='mit_b5',
-	encoder_weights='imagenet',
-	in_channels=3,
-	classes=1,
+    encoder_name="mit_b5",
+    encoder_weights="imagenet",
+    in_channels=3,
+    classes=1,
 ).to(memory_format=torch.channels_last)
 model = torch.compile(model)
 
@@ -48,37 +45,36 @@ model = model.to(memory_format=torch.channels_last, device=device)
 model.eval()
 
 
-# load image patch
+# load image patch 
 image = None
 with rasterio.open(pathtotile) as src:
-	image = src.read()
+    image = src.read()
 
-	# Reshape the image tensor to have 3 channels
-	image = image.transpose(1, 2, 0)
 
-	image_transforms = transforms.Compose(
-		[
-			transforms.ToTensor(),
-			transforms.Normalize(
-				mean=[0.485, 0.456, 0.406],
-				std=[0.229, 0.224, 0.225],
-			),
-		]
-	)
-	image = image_transforms(image).float().contiguous()
+    # Reshape the image tensor to have 3 channels
+    image = image.transpose(1, 2, 0)
 
-	# convert to torch tensor
-	image = torch.tensor(image)
+    image_transforms = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize(
+            mean=[0.485, 0.456, 0.406],
+            std=[0.229, 0.224, 0.225],
+        ),
+    ])
+    image = image_transforms(image).float().contiguous()
 
-	# add batch dimension
-	image = image.unsqueeze(0)
+    # convert to torch tensor
+    image = torch.tensor(image)
 
-	# to device
-	image = image.to(device=device, memory_format=torch.channels_last)
+    # add batch dimension
+    image = image.unsqueeze(0)
+
+    # to device
+    image = image.to(device=device, memory_format=torch.channels_last)
 
 output = model(image)
 output = torch.sigmoid(output)
-output = output > 0.5
+output = (output > 0.5)
 
 # save output to disk as geotiff with same projection as input
 output = output.cpu().detach().numpy()
@@ -87,24 +83,24 @@ output = output.squeeze()
 
 # get affine transformation from input
 with rasterio.open(pathtotile) as src:
-	transform = src.transform
-	crs = src.crs
-	nodata = src.nodata
+    transform = src.transform
+    crs = src.crs
+    nodata = src.nodata
 
 # outpath is filename replaced with _deadwood.tif, but only filename
-output_path = pathtotile.split('/')[-1].replace('.tif', '_deadwood_heavy.tif')
+output_path = pathtotile.split("/")[-1].replace(".tif", "_deadwood_heavy.tif")
 
 # save output to disk
 with rasterio.open(
-	output_path,
-	'w',
-	driver='GTiff',
-	height=output.shape[0],
-	width=output.shape[1],
-	count=1,
-	dtype=output.dtype,
-	crs=crs,
-	transform=transform,
-	nodata=nodata,
+    output_path,
+    "w",
+    driver="GTiff",
+    height=output.shape[0],
+    width=output.shape[1],
+    count=1,
+    dtype=output.dtype,
+    crs=crs,
+    transform=transform,
+    nodata=nodata,
 ) as dst:
-	dst.write(output, 1)
+    dst.write(output, 1)

--- a/tileinference.py
+++ b/tileinference.py
@@ -17,14 +17,14 @@ from shapely.geometry import Polygon, MultiPolygon
 
 # DEADWOOD_MODEL_PATH = "/net/scratch/cmosig/model.safetensors"
 # DEADWOOD_MODEL_PATH = "/net/scratch/jmoehring/checkpoints/3d_18k_100e_vanilla_tversky_a01b09g2/fold_0_epoch_99/model.safetensors"
-DEADWOOD_MODEL_PATH = "/net/scratch/cmosig/experiment_dir_deadwood_segmentation/segformer_b5_oversample_newdata/fold_0_epoch_74/model.safetensors"
+DEADWOOD_MODEL_PATH = '/net/scratch/cmosig/experiment_dir_deadwood_segmentation/segformer_b5_oversample_newdata/fold_0_epoch_74/model.safetensors'
 
-# pathtotile = sys.argv[1]    
-pathtotile = "/net/scratch/jmoehring/tiles/spain_20_09_2023_south_tejeda_1_ortho/0.08/1588_4484.tif"
+# pathtotile = sys.argv[1]
+pathtotile = '/net/scratch/jmoehring/tiles/spain_20_09_2023_south_tejeda_1_ortho/0.08/1588_4484.tif'
 # pathtotile = "/net/scratch/jmoehring/tiles/spain_20_09_2023_south_tejeda_1_ortho/0.08/1588_900.tif"
 
 # preferably use GPU
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 # model with three input channels (RGB)
 # model = UNet(
@@ -33,10 +33,10 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 # ).to(memory_format=torch.channels_last)
 
 model = smp.Unet(
-    encoder_name="mit_b5",
-    encoder_weights="imagenet",
-    in_channels=3,
-    classes=1,
+	encoder_name='mit_b5',
+	encoder_weights='imagenet',
+	in_channels=3,
+	classes=1,
 ).to(memory_format=torch.channels_last)
 model = torch.compile(model)
 
@@ -45,36 +45,37 @@ model = model.to(memory_format=torch.channels_last, device=device)
 model.eval()
 
 
-# load image patch 
+# load image patch
 image = None
 with rasterio.open(pathtotile) as src:
-    image = src.read()
+	image = src.read()
 
+	# Reshape the image tensor to have 3 channels
+	image = image.transpose(1, 2, 0)
 
-    # Reshape the image tensor to have 3 channels
-    image = image.transpose(1, 2, 0)
+	image_transforms = transforms.Compose(
+		[
+			transforms.ToTensor(),
+			transforms.Normalize(
+				mean=[0.485, 0.456, 0.406],
+				std=[0.229, 0.224, 0.225],
+			),
+		]
+	)
+	image = image_transforms(image).float().contiguous()
 
-    image_transforms = transforms.Compose([
-        transforms.ToTensor(),
-        transforms.Normalize(
-            mean=[0.485, 0.456, 0.406],
-            std=[0.229, 0.224, 0.225],
-        ),
-    ])
-    image = image_transforms(image).float().contiguous()
+	# convert to torch tensor
+	image = torch.tensor(image)
 
-    # convert to torch tensor
-    image = torch.tensor(image)
+	# add batch dimension
+	image = image.unsqueeze(0)
 
-    # add batch dimension
-    image = image.unsqueeze(0)
-
-    # to device
-    image = image.to(device=device, memory_format=torch.channels_last)
+	# to device
+	image = image.to(device=device, memory_format=torch.channels_last)
 
 output = model(image)
 output = torch.sigmoid(output)
-output = (output > 0.5)
+output = output > 0.5
 
 # save output to disk as geotiff with same projection as input
 output = output.cpu().detach().numpy()
@@ -83,24 +84,24 @@ output = output.squeeze()
 
 # get affine transformation from input
 with rasterio.open(pathtotile) as src:
-    transform = src.transform
-    crs = src.crs
-    nodata = src.nodata
+	transform = src.transform
+	crs = src.crs
+	nodata = src.nodata
 
 # outpath is filename replaced with _deadwood.tif, but only filename
-output_path = pathtotile.split("/")[-1].replace(".tif", "_deadwood_heavy.tif")
+output_path = pathtotile.split('/')[-1].replace('.tif', '_deadwood_heavy.tif')
 
 # save output to disk
 with rasterio.open(
-    output_path,
-    "w",
-    driver="GTiff",
-    height=output.shape[0],
-    width=output.shape[1],
-    count=1,
-    dtype=output.dtype,
-    crs=crs,
-    transform=transform,
-    nodata=nodata,
+	output_path,
+	'w',
+	driver='GTiff',
+	height=output.shape[0],
+	width=output.shape[1],
+	count=1,
+	dtype=output.dtype,
+	crs=crs,
+	transform=transform,
+	nodata=nodata,
 ) as dst:
-    dst.write(output, 1)
+	dst.write(output, 1)

--- a/tileinference.py
+++ b/tileinference.py
@@ -6,6 +6,7 @@ from torch.utils.data import DataLoader
 from unet_model import UNet
 from torchvision.transforms.functional import crop
 import os
+from pathlib import Path
 
 import geopandas as gpd
 import numpy as np
@@ -17,14 +18,16 @@ from shapely.geometry import Polygon, MultiPolygon
 
 # DEADWOOD_MODEL_PATH = "/net/scratch/cmosig/model.safetensors"
 # DEADWOOD_MODEL_PATH = "/net/scratch/jmoehring/checkpoints/3d_18k_100e_vanilla_tversky_a01b09g2/fold_0_epoch_99/model.safetensors"
-DEADWOOD_MODEL_PATH = "/net/scratch/cmosig/experiment_dir_deadwood_segmentation/segformer_b5_oversample_newdata/fold_0_epoch_74/model.safetensors"
+DEADWOOD_MODEL_PATH = str(
+	Path(__file__).parent.parent.parent.parent.parent / 'assets' / 'models' / 'segformer_b5_fold_0_epoch_74.safetensors'
+)
 
-# pathtotile = sys.argv[1]    
-pathtotile = "/net/scratch/jmoehring/tiles/spain_20_09_2023_south_tejeda_1_ortho/0.08/1588_4484.tif"
+# pathtotile = sys.argv[1]
+pathtotile = '/net/scratch/jmoehring/tiles/spain_20_09_2023_south_tejeda_1_ortho/0.08/1588_4484.tif'
 # pathtotile = "/net/scratch/jmoehring/tiles/spain_20_09_2023_south_tejeda_1_ortho/0.08/1588_900.tif"
 
 # preferably use GPU
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 # model with three input channels (RGB)
 # model = UNet(
@@ -33,10 +36,10 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 # ).to(memory_format=torch.channels_last)
 
 model = smp.Unet(
-    encoder_name="mit_b5",
-    encoder_weights="imagenet",
-    in_channels=3,
-    classes=1,
+	encoder_name='mit_b5',
+	encoder_weights='imagenet',
+	in_channels=3,
+	classes=1,
 ).to(memory_format=torch.channels_last)
 model = torch.compile(model)
 
@@ -45,36 +48,37 @@ model = model.to(memory_format=torch.channels_last, device=device)
 model.eval()
 
 
-# load image patch 
+# load image patch
 image = None
 with rasterio.open(pathtotile) as src:
-    image = src.read()
+	image = src.read()
 
+	# Reshape the image tensor to have 3 channels
+	image = image.transpose(1, 2, 0)
 
-    # Reshape the image tensor to have 3 channels
-    image = image.transpose(1, 2, 0)
+	image_transforms = transforms.Compose(
+		[
+			transforms.ToTensor(),
+			transforms.Normalize(
+				mean=[0.485, 0.456, 0.406],
+				std=[0.229, 0.224, 0.225],
+			),
+		]
+	)
+	image = image_transforms(image).float().contiguous()
 
-    image_transforms = transforms.Compose([
-        transforms.ToTensor(),
-        transforms.Normalize(
-            mean=[0.485, 0.456, 0.406],
-            std=[0.229, 0.224, 0.225],
-        ),
-    ])
-    image = image_transforms(image).float().contiguous()
+	# convert to torch tensor
+	image = torch.tensor(image)
 
-    # convert to torch tensor
-    image = torch.tensor(image)
+	# add batch dimension
+	image = image.unsqueeze(0)
 
-    # add batch dimension
-    image = image.unsqueeze(0)
-
-    # to device
-    image = image.to(device=device, memory_format=torch.channels_last)
+	# to device
+	image = image.to(device=device, memory_format=torch.channels_last)
 
 output = model(image)
 output = torch.sigmoid(output)
-output = (output > 0.5)
+output = output > 0.5
 
 # save output to disk as geotiff with same projection as input
 output = output.cpu().detach().numpy()
@@ -83,25 +87,24 @@ output = output.squeeze()
 
 # get affine transformation from input
 with rasterio.open(pathtotile) as src:
-    transform = src.transform
-    crs = src.crs
-    nodata = src.nodata
+	transform = src.transform
+	crs = src.crs
+	nodata = src.nodata
 
 # outpath is filename replaced with _deadwood.tif, but only filename
-output_path = pathtotile.split("/")[-1].replace(".tif", "_deadwood_heavy.tif")
+output_path = pathtotile.split('/')[-1].replace('.tif', '_deadwood_heavy.tif')
 
 # save output to disk
 with rasterio.open(
-    output_path,
-    "w",
-    driver="GTiff",
-    height=output.shape[0],
-    width=output.shape[1],
-    count=1,
-    dtype=output.dtype,
-    crs=crs,
-    transform=transform,
-    nodata=nodata,
+	output_path,
+	'w',
+	driver='GTiff',
+	height=output.shape[0],
+	width=output.shape[1],
+	count=1,
+	dtype=output.dtype,
+	crs=crs,
+	transform=transform,
+	nodata=nodata,
 ) as dst:
-    dst.write(output, 1)
-
+	dst.write(output, 1)

--- a/treecover/tree_cover_inference.py
+++ b/treecover/tree_cover_inference.py
@@ -12,61 +12,59 @@ from ..common import mask_to_polygons
 # Define threshold for tree cover detection
 TCD_THRESHOLD = 200
 
+
 def inference_forestcover(input_tif: str):
-    """
-    Run tree cover detection on an orthophoto and return the polygons.
-    
-    Args:
-        input_tif (str): Path to the input GeoTIFF file
-        
-    Returns:
-        list: List of polygons representing tree cover
-    """
-    with tempfile.TemporaryDirectory() as tempdir:
-        # Reproject tif to 10cm resolution in a projected CRS
-        temp_reproject_path = os.path.join(tempdir, os.path.basename(input_tif))
-        
-        # Use the TCD utility to convert and resample the image
-        convert_to_projected(
-            input_tif, 
-            temp_reproject_path,
-            resample=True,
-            target_gsd_m=0.1,  # 10cm resolution
-            dst_crs="EPSG:3395"  # Mercator projection
-        )
+	"""
+	Run tree cover detection on an orthophoto and return the polygons.
 
-        # Initialize the TCD pipeline with the segformer model
-        pipeline = Pipeline(model_or_config="restor/tcd-segformer-mit-b5")
+	Args:
+	    input_tif (str): Path to the input GeoTIFF file
 
-        # Run prediction
-        result = pipeline.predict(temp_reproject_path)
+	Returns:
+	    list: List of polygons representing tree cover
+	"""
+	with tempfile.TemporaryDirectory() as tempdir:
+		# Reproject tif to 10cm resolution in a projected CRS
+		temp_reproject_path = os.path.join(tempdir, os.path.basename(input_tif))
 
-        # The confidence map is a numpy array in the result object
-        # Check the type of confidence_map to handle it properly
-        print(f"Type of confidence_map: {type(result.confidence_map)}")
-        
-        # If it's a DatasetReader, we need to read the data
-        if hasattr(result.confidence_map, 'read'):
-            # Read the first band as a numpy array
-            confidence_map = result.confidence_map.read(1)
-        elif isinstance(result.confidence_map, np.ndarray):
-            # It's already a numpy array
-            confidence_map = result.confidence_map
-        else:
-            # Try to convert to numpy array
-            try:
-                confidence_map = np.array(result.confidence_map)
-            except Exception as e:
-                raise TypeError(f"Cannot convert confidence_map to numpy array: {e}")
-        
-        
-        # Threshold the output image to get binary mask
-        outimage = (confidence_map > TCD_THRESHOLD).astype(np.uint8)
-        
-        # Open the dataset to get the transform for mask_to_polygons
-        with rasterio.open(temp_reproject_path) as dataset:
-            polygons = mask_to_polygons(outimage, dataset)
+		# Use the TCD utility to convert and resample the image
+		convert_to_projected(
+			input_tif,
+			temp_reproject_path,
+			resample=True,
+			target_gsd_m=0.1,  # 10cm resolution
+			dst_crs='EPSG:3395',  # Mercator projection
+		)
 
-        return polygons
+		# Initialize the TCD pipeline with the segformer model
+		pipeline = Pipeline(model_or_config='restor/tcd-segformer-mit-b5')
 
+		# Run prediction
+		result = pipeline.predict(temp_reproject_path)
 
+		# The confidence map is a numpy array in the result object
+		# Check the type of confidence_map to handle it properly
+		print(f'Type of confidence_map: {type(result.confidence_map)}')
+
+		# If it's a DatasetReader, we need to read the data
+		if hasattr(result.confidence_map, 'read'):
+			# Read the first band as a numpy array
+			confidence_map = result.confidence_map.read(1)
+		elif isinstance(result.confidence_map, np.ndarray):
+			# It's already a numpy array
+			confidence_map = result.confidence_map
+		else:
+			# Try to convert to numpy array
+			try:
+				confidence_map = np.array(result.confidence_map)
+			except Exception as e:
+				raise TypeError(f'Cannot convert confidence_map to numpy array: {e}')
+
+		# Threshold the output image to get binary mask
+		outimage = (confidence_map > TCD_THRESHOLD).astype(np.uint8)
+
+		# Open the dataset to get the transform for mask_to_polygons
+		with rasterio.open(temp_reproject_path) as dataset:
+			polygons = mask_to_polygons(outimage, dataset)
+
+		return polygons

--- a/treecover/tree_cover_inference.py
+++ b/treecover/tree_cover_inference.py
@@ -1,24 +1,71 @@
 import tempfile
 import os
+import numpy as np
+import rasterio
+from tcd_pipeline.pipeline import Pipeline
+from tcd_pipeline.util import convert_to_projected
+from shapely.geometry import Polygon, MultiPolygon
+
+# Import from common module
+from ..common import mask_to_polygons
+
+# Define threshold for tree cover detection
+TCD_THRESHOLD = 200
 
 def inference_forestcover(input_tif: str):
+    """
+    Run tree cover detection on an orthophoto and return the polygons.
+    
+    Args:
+        input_tif (str): Path to the input GeoTIFF file
         
+    Returns:
+        list: List of polygons representing tree cover
+    """
     with tempfile.TemporaryDirectory() as tempdir:
-        # reproject tif to 10cm
-        temp_reproject_path = os.path.join(temp, input_tif.str.split('/')[-1])
-        reproject_to_10cm(input_tif, temp_reproject_path)
+        # Reproject tif to 10cm resolution in a projected CRS
+        temp_reproject_path = os.path.join(tempdir, os.path.basename(input_tif))
+        
+        # Use the TCD utility to convert and resample the image
+        convert_to_projected(
+            input_tif, 
+            temp_reproject_path,
+            resample=True,
+            target_gsd_m=0.1,  # 10cm resolution
+            dst_crs="EPSG:3395"  # Mercator projection
+        )
 
+        # Initialize the TCD pipeline with the segformer model
         pipeline = Pipeline(model_or_config="restor/tcd-segformer-mit-b5")
 
-        res = pipeline.predict(temp_reproject_path)
+        # Run prediction
+        result = pipeline.predict(temp_reproject_path)
 
-        dataset_reader_result = res.confidence_map
-
-        # threshold the output image
-        outimage = (res.confidence_map > TCD_THRESHOLD).astype(np.uint8)
-
-        # convert to polygons
-        polygons = mask_to_polygons(outimage, dataset_reader_result)
+        # The confidence map is a numpy array in the result object
+        # Check the type of confidence_map to handle it properly
+        print(f"Type of confidence_map: {type(result.confidence_map)}")
+        
+        # If it's a DatasetReader, we need to read the data
+        if hasattr(result.confidence_map, 'read'):
+            # Read the first band as a numpy array
+            confidence_map = result.confidence_map.read(1)
+        elif isinstance(result.confidence_map, np.ndarray):
+            # It's already a numpy array
+            confidence_map = result.confidence_map
+        else:
+            # Try to convert to numpy array
+            try:
+                confidence_map = np.array(result.confidence_map)
+            except Exception as e:
+                raise TypeError(f"Cannot convert confidence_map to numpy array: {e}")
+        
+        
+        # Threshold the output image to get binary mask
+        outimage = (confidence_map > TCD_THRESHOLD).astype(np.uint8)
+        
+        # Open the dataset to get the transform for mask_to_polygons
+        with rasterio.open(temp_reproject_path) as dataset:
+            polygons = mask_to_polygons(outimage, dataset)
 
         return polygons
 


### PR DESCRIPTION
This pull request mainly includes two changes: caching the segformer_b5 model and fixing a multiprocessing bug.

## Caching the segformer_b5 Model
While debugging, I noticed that the part that takes the longest is not so much the torch.compile(model), but rather the initial load of the ImageNet model:

```
model = smp.Unet(
    encoder_name="mit_b5",
    encoder_weights="imagenet",
    in_channels=3,
    classes=1,
).to(memory_format=torch.channels_last)
```
So, I implemented a simple caching mechanism that saves the model using state_dict after the initial load and reuses the weights in subsequent processes.

## Fixing the Multiprocessing Bug
At least for me, I could not run the model with more than one data loader worker.

```
Caught RasterioIOError in DataLoader worker process 1.
```
I think this is what's happening:

When you use WarpedVRT in image_reprojector(), it returns a VRT object that maintains an open file handle to the original dataset.
When PyTorch's DataLoader creates worker processes, it tries to pickle (serialize) the dataset to pass it to worker processes.
The problem: File handles cannot be properly pickled and shared between processes. When worker processes try to access the VRT object, they encounter issues with the underlying file handle.
To fix this, I modified image_reprojector() to return memory files instead of a file handle. MemoryFile creates an in-memory representation of the data that doesn't rely on the original file handle. This in-memory representation can be properly serialized and shared between processes.

However, I'm not entirely happy with this implementation since I need to load the entire file into memory, which could be an issue for very large files. So I’d be curious to hear how you implemented this. I assume you're using more than one data loader worker?

So instead of merging directly, lets first try to find a sustainable solution to the multiprocessing problem.